### PR TITLE
Add output file names to HTML + misc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 * Ensure `yarn` is installed: `npm install -g yarn`
 * Ensure `typescript` compiler is installed: `npm install -g typescript`
 * Ensure dependencies are installed: `yarn`
+* Change code in the `.literate` files
+* Rebuild with the `VSCode` command `Literate: Process` (`literate.process`)
 * Check linting: `yarn pretest`
 * Compile code: `yarn esbuild`
 

--- a/literate/literate.html
+++ b/literate/literate.html
@@ -1521,7 +1521,7 @@ the <code>span</code> with the <code>literate-name-tag</code> class.</p>
   <span class="hljs-keyword">function</span> <span class="hljs-title function_">cleanHighlights</span>(<span class="hljs-params">match : <span class="hljs-built_in">string</span>, _: <span class="hljs-built_in">number</span>, __: <span class="hljs-built_in">string</span></span>)
   {
     <span class="hljs-keyword">let</span> internal = match.<span class="hljs-title function_">replaceAll</span>(<span class="hljs-variable constant_">FRAGMENT_HTML_CLEANUP_RE</span>, <span class="hljs-string">&quot;$2&quot;</span>);
-    <span class="hljs-keyword">return</span> <span class="hljs-string">`&lt;span class=&quot;literate-tag-name&quot;&gt;<span class="hljs-subst">${internal}</span>&lt;/span&gt;`</span>
+    <span class="hljs-keyword">return</span> <span class="hljs-string">`&lt;span class=&quot;literate-tag-name&quot;&gt;<span class="hljs-subst">${internal}</span>&lt;/span&gt;`</span>;
   }
   <span class="hljs-keyword">return</span> rendered
     .<span class="hljs-title function_">replaceAll</span>(

--- a/literate/literate.html
+++ b/literate/literate.html
@@ -1471,10 +1471,11 @@ If we have a match we prepare the <code>HTML</code> code to essentially wrap aro
         <span class="hljs-keyword">if</span> (name) {
           root = root || <span class="hljs-string">&#x27;&#x27;</span>;
           add = add || <span class="hljs-string">&#x27;&#x27;</span>;
+          fileName = fileName || <span class="hljs-string">&#x27;&#x27;</span>;
           rendered = <span class="hljs-title function_">protectFragmentTags</span>(rendered);
           rendered =
 <span class="hljs-string">`&lt;div class=&quot;codefragment&quot;&gt;
-&lt;div class=&quot;fragmentname&quot;&gt;&amp;lt;&amp;lt;<span class="hljs-subst">${name}</span>&amp;gt;&amp;gt;<span class="hljs-subst">${root}</span><span class="hljs-subst">${add}</span>&lt;/div&gt;
+&lt;div class=&quot;fragmentname&quot;&gt;&amp;lt;&amp;lt;<span class="hljs-subst">${name}</span>&amp;gt;&amp;gt;<span class="hljs-subst">${root}</span><span class="hljs-subst">${add}</span> <span class="hljs-subst">${fileName}</span>&lt;/div&gt;
 &lt;div class=&quot;code&quot;&gt;
 <span class="hljs-subst">${rendered}</span>
 &lt;/div&gt;

--- a/literate/literate.literate
+++ b/literate/literate.literate
@@ -1466,7 +1466,7 @@ function protectFragmentTags(rendered : string) {
   function cleanHighlights(match : string, _: number, __: string)
   {
     let internal = match.replaceAll(FRAGMENT_HTML_CLEANUP_RE, "$2");
-    return `<span class="literate-tag-name">${internal}</span>`
+    return `<span class="literate-tag-name">${internal}</span>`;
   }
   return rendered
     .replaceAll(

--- a/literate/literate.literate
+++ b/literate/literate.literate
@@ -1416,10 +1416,11 @@ function renderCodeFence(tokens : Token[],
         if (name) {
           root = root || '';
           add = add || '';
+          fileName = fileName || '';
           rendered = protectFragmentTags(rendered);
           rendered =
 `<div class="codefragment">
-<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add}</div>
+<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add} ${fileName}</div>
 <div class="code">
 ${rendered}
 </div>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -320,7 +320,7 @@ function protectFragmentTags(rendered : string) {
   function cleanHighlights(match : string, _: number, __: string)
   {
     let internal = match.replaceAll(FRAGMENT_HTML_CLEANUP_RE, "$2");
-    return `<span class="literate-tag-name">${internal}</span>`
+    return `<span class="literate-tag-name">${internal}</span>`;
   }
   return rendered
     .replaceAll(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,10 +350,11 @@ function renderCodeFence(tokens : Token[],
         if (name) {
           root = root || '';
           add = add || '';
+          fileName = fileName || '';
           rendered = protectFragmentTags(rendered);
           rendered =
 `<div class="codefragment">
-<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add}</div>
+<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add} ${fileName}</div>
 <div class="code">
 ${rendered}
 </div>


### PR DESCRIPTION
Each commit deals with a distinct issue.  In order:
1. Fix a missing `;` that triggered some errors/warnings.
2. Add filename to the codefence rendered in HTML--if one was specified
3. A bit more instruction on developing code.  As noted in that commit, I would have loved to explain how the instructions relate to what happens automatically with `F5`, but I'm not sure what that is...