### PR TITLE
add output file name + contributions (rb3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@
 * Check linting: `yarn pretest`
 * Compile code: `yarn esbuild`
 
+If the code changes in `.literate` files don't automatically rebuild the HTML and designated source files you can run the `VSCode` command `Literate: Process (literate.process)`.
+
 To test the extension it is best to temporarily disable the installed extension
 before starting the test. Once disabled go to the Run and Debug panel and select
 `Run Extension`. Click the green arrow to start debugging or hit `F5`. This will

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,4 +4,5 @@ People who have contributed to the Literate Programming extension:
 
 * Konrad Kleine
 * Nicolas Lelong
+* Ross Boylan <ross.boylan@ucsf.edu>
 * _add name here_

--- a/literate/literate.html
+++ b/literate/literate.html
@@ -1491,10 +1491,11 @@ If we have a match we prepare the <code>HTML</code> code to essentially wrap aro
         <span class="hljs-keyword">if</span> (name) {
           root = root || <span class="hljs-string">&#x27;&#x27;</span>;
           add = add || <span class="hljs-string">&#x27;&#x27;</span>;
+          fileName = fileName || <span class="hljs-string">&#x27;&#x27;</span>;
           rendered = <span class="hljs-title function_">protectFragmentTags</span>(rendered);
           rendered =
 <span class="hljs-string">`&lt;div class=&quot;codefragment&quot;&gt;
-&lt;div class=&quot;fragmentname&quot;&gt;&amp;lt;&amp;lt;<span class="hljs-subst">${name}</span>&amp;gt;&amp;gt;<span class="hljs-subst">${root}</span><span class="hljs-subst">${add}</span>&lt;/div&gt;
+&lt;div class=&quot;fragmentname&quot;&gt;&amp;lt;&amp;lt;<span class="hljs-subst">${name}</span>&amp;gt;&amp;gt;<span class="hljs-subst">${root}</span><span class="hljs-subst">${add}</span> <span class="hljs-subst">${fileName}</span>&lt;/div&gt;
 &lt;div class=&quot;code&quot;&gt;
 <span class="hljs-subst">${rendered}</span>
 &lt;/div&gt;

--- a/literate/literate.literate
+++ b/literate/literate.literate
@@ -1436,10 +1436,11 @@ function renderCodeFence(tokens : Token[],
         if (name) {
           root = root || '';
           add = add || '';
+          fileName = fileName || '';
           rendered = protectFragmentTags(rendered);
           rendered =
 `<div class="codefragment">
-<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add}</div>
+<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add} ${fileName}</div>
 <div class="code">
 ${rendered}
 </div>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,10 +350,11 @@ function renderCodeFence(tokens : Token[],
         if (name) {
           root = root || '';
           add = add || '';
+          fileName = fileName || '';
           rendered = protectFragmentTags(rendered);
           rendered =
 `<div class="codefragment">
-<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add}</div>
+<div class="fragmentname">&lt;&lt;${name}&gt;&gt;${root}${add} ${fileName}</div>
 <div class="code">
 ${rendered}
 </div>


### PR DESCRIPTION
I made these changes off of the most current head.
Relative to my first try commits
1) dropped; already done in main
2) same: add file name
3) eliminated my changing to CONTRIBUTING.md but added your alternative wording.  I did find I needed the command, probably because I disabled the extension earlier.  Added self as contributor.

BTW, I'm getting lots of differences that are only changes in line endings.  The stuff in the archive looks Unixy (0xa), while stuff generated on my Windows machine is Windowsy (0xd, 0xa).  So
a) it would be nice if that didn't happen
b) you may want to regenerate the derived files that are included in the commits.